### PR TITLE
Cardano Node 1.35.3 bump

### DIFF
--- a/build-common.sh
+++ b/build-common.sh
@@ -2,8 +2,11 @@
 
 # Also change HaskellNix in nix/sources.json
 # and the Hydra build in nix/docker/node/default.nix
-CARDANO_VER="1.35.0"
-CARDANO_REV="-dev"
+# Also check nix/libsodium/default.nix
+# Also check nix/secp256k1/default.nix
+# Also check libsodium + secp256k1 in nix/cardano/Dockerfile
+CARDANO_VER="1.35.3"
+CARDANO_REV="-rev1"
 
 # https://github.com/tstack/lnav
 DEBIAN_VER="10"
@@ -11,12 +14,15 @@ LNAV_VER="0.10.1"
 
 # https://github.com/cardano-community/guild-operators/blob/alpha/scripts/cnode-helper-scripts/gLiveView.sh#L60
 # Also change change in nix/gLiveView/default.nix
-GLVIEW_VER="1.27.0"
+GLVIEW_VER="1.27.1"
 
 # https://github.com/cardano-community/cncli
-CNCLI_VER="5.0.5"
+CNCLI_VER="5.1.0"
 
+# Check: https://github.com/input-output-hk/cardano-node/blob/master/doc/getting-started/install.md
+# Check: https://github.com/input-output-hk/cardano-node/blob/master/.github/workflows/haskell.yml#L63
 CABAL_VER="3.6.2.0"
+# Check: https://github.com/input-output-hk/cardano-node/blob/master/.github/workflows/haskell.yml#L27
 GHC_VER="8.10.7"
 
 ARCH=`uname -m`

--- a/build-common.sh
+++ b/build-common.sh
@@ -8,8 +8,11 @@
 CARDANO_VER="1.35.3"
 CARDANO_REV="-rev1"
 
+# Also check nix/cardano/Dockerfile
+# Also check nix/cncli/Dockerfile
+# Also check nix/docker/baseImage
+DEBIAN_VER="11"
 # https://github.com/tstack/lnav
-DEBIAN_VER="10"
 LNAV_VER="0.10.1"
 
 # https://github.com/cardano-community/guild-operators/blob/alpha/scripts/cnode-helper-scripts/gLiveView.sh#L60

--- a/nix/cardano/Dockerfile
+++ b/nix/cardano/Dockerfile
@@ -10,7 +10,7 @@ ARG ARCH
 
 ## Install dependencies, secp256k1 and libsodium #################################################################################
 
-FROM debian:10-slim as builderA
+FROM debian:11-slim as builderA
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/nix/cncli/Dockerfile
+++ b/nix/cncli/Dockerfile
@@ -1,7 +1,7 @@
 
 ## Build + Install cncli ########################################################################################
 
-FROM debian:10-slim as builderA
+FROM debian:11-slim as builderA
 
 ARG CNCLI_VER
 ARG ARCH

--- a/nix/docker/README.md
+++ b/nix/docker/README.md
@@ -173,7 +173,7 @@ curl http://localhost:12798/metrics/xyz.../liveness | sort
 ```
 ## Bare Metal Build
 
-Debian 10 (Buster)
+Debian 11
 
 ```
 # Install system dependencies

--- a/nix/docker/baseImage/Dockerfile
+++ b/nix/docker/baseImage/Dockerfile
@@ -8,7 +8,7 @@ ARG LNAV_VER
 
 ## Install required dependencies ######################################################################################
 
-FROM debian:10-slim as builderA
+FROM debian:11-slim as builderA
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/nix/docker/node/default.nix
+++ b/nix/docker/node/default.nix
@@ -22,9 +22,10 @@
   ghcVersion,
   glvVersion,
 
-  # https://hydra.iohk.io/build/12179730/download/1/index.html
-  hydraBuild ? "8111119",
-
+  # Please see build number for cardano-deployment / cardano-html through "Hydra binaries" download link from the release page e.q. https://hydra.iohk.io/build/17428016#tabs-constituents
+  # https://hydra.iohk.io/build/17427100/download/1/index.html
+  hydraBuild ? "17427100",
+  
   baseImage ? import ../baseImage { inherit debianVersion; },
   cardano ? import ../../cardano { inherit cardanoVersion cardanoRev cabalVersion ghcVersion; },
   gLiveView ? import ../../gLiveView { inherit glvVersion; },

--- a/nix/gLiveView/default.nix
+++ b/nix/gLiveView/default.nix
@@ -27,7 +27,7 @@ pkgs.stdenv.mkDerivation {
   src = builtins.fetchGit {
     name = "guild-operators";
     url = "https://github.com/cardano-community/guild-operators.git";
-    rev = "0dfc77e7a3d16856c048cb97da9953921f19ca22";
+    rev = "744bd6ab34617f2edab04b3436bd5db8fdc1a6ce";
     ref = "alpha";
   };
 

--- a/nix/libsodium/default.nix
+++ b/nix/libsodium/default.nix
@@ -10,8 +10,9 @@
 pkgs.stdenv.mkDerivation {
 
   pname = "libsodium";
-  version = "1.35.0";
+  version = "1.35.3";
 
+  # Check: https://github.com/input-output-hk/cardano-node/blob/1.35.3/doc/getting-started/install.md#installing-libsodium
   src = builtins.fetchGit {
     url = "https://github.com/input-output-hk/libsodium";
     allRefs = true;

--- a/nix/secp256k1/default.nix
+++ b/nix/secp256k1/default.nix
@@ -10,8 +10,9 @@
 pkgs.stdenv.mkDerivation {
 
   pname = "secp256k1";
-  version = "1.35.0";
+  version = "1.35.3";
 
+  # Check: https://github.com/input-output-hk/cardano-node/blob/1.35.3/doc/getting-started/install.md#installing-secp256k1
   src = builtins.fetchGit {
     url = "https://github.com/bitcoin-core/secp256k1";
     rev = "ac83be33d0956faf6b7f61a60ab524ef7d6a473a";

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
       "homepage": "https://github.com/nmattia/niv",
       "owner": "nmattia",
       "repo": "niv",
-      "rev": "af958e8057f345ee1aca714c1247ef3ba1c15f5e",
+      "rev": "82e5cd1ad3c387863f0545d7591512e76ab0fc41",
       "sha256": "1qjavxabbrsh73yck5dcq8jggvh3r2jkbr6b5nlz5d9yrqm9255n",
       "type": "tarball",
-      "url": "https://github.com/nmattia/niv/archive/af958e8057f345ee1aca714c1247ef3ba1c15f5e.tar.gz",
+      "url": "https://github.com/nmattia/niv/archive/82e5cd1ad3c387863f0545d7591512e76ab0fc41.tar.gz",
       "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "haskellNix": {
@@ -17,11 +17,11 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "_see": "https://github.com/input-output-hk/cardano-node/blob/1.34.1/flake.lock#L844",
-        "rev": "14f740c7c8f535581c30b1697018e389680e24cb",
-        "sha256": "07mcd5daiqihzzyw2da11v45xxh8fz65a3g88v2i8cdk6ll7ysc3",
+        "_see": "https://github.com/input-output-hk/cardano-node/blob/1.35.3/flake.lock#L3253",
+        "rev": "3fbb17e63c4e052c8289858fa6444d1c66ab6f52",
+        "sha256": "ea8Celj9aPb1HG8mGNorqMr5+3xZzjuhjF89Mj4hSLU=",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/14f740c7c8f535581c30b1697018e389680e24cb.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/3fbb17e63c4e052c8289858fa6444d1c66ab6f52.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
- Cardano Node 1.35.3
- Base docker image Debian 11
- gLiveView 1.27.1
- CNCLI 5.1.0
- Fixes #2